### PR TITLE
Fix MQTT JSON mode

### DIFF
--- a/Software/EmonESP/platformio.ini
+++ b/Software/EmonESP/platformio.ini
@@ -26,7 +26,7 @@ version = -DBUILD_TAG=2.6
 platform = espressif32
 framework = arduino
 lib_deps =
-	PubSubClient@2.6
+	PubSubClient@2.8
 	ESP Async WebServer@1.2.3
 	AsyncTCP@1.1.1
 	circuitsetup/ATM90E32

--- a/Software/EmonESP/src/mqtt.cpp
+++ b/Software/EmonESP/src/mqtt.cpp
@@ -52,7 +52,6 @@ static int mqtt_connection_error_count = 0;
 boolean mqtt_connect()
 {
   DBUGS.println("MQTT Connecting...");
-  DBUGS.println(mqttclient.state());
 
   if (espClient.connect(mqtt_server.c_str(), 1883, MQTT_TIMEOUT * 1000) != 1)
   {
@@ -61,6 +60,8 @@ boolean mqtt_connect()
   }
 
   espClient.setTimeout(MQTT_TIMEOUT);
+  mqttclient.setSocketTimeout(MQTT_TIMEOUT);
+  mqttclient.setBufferSize(MAX_DATA_LEN + 200);
 
 #ifdef ESP32
   String strID = String((uint32_t)(ESP.getEfuseMac() >> 16), HEX);


### PR DESCRIPTION
I see that you've brought in the changes I've made for MQTT JSON mode.  Previously I had to modify the PubSubClient source to fix the buffer size, but this was not captured in my Git repository.

PubSubClient v2.8 now includes functions to fix this issue the correct way.  This pull request includes the buffer size fixes as well as setting the timeout for PubSubClient.
