### PR TITLE
Update Waveshare Ethernet main board CS pin mappings

### DIFF
--- a/Software/ESPHome/6chan_energy_meter_1-addon_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_1-addon_ethernet_waveshare.yaml
@@ -143,9 +143,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 - id: !extend ${addon1_id1}
   cs_pin: 1
 #- id: !extend ${addon1_id2}

--- a/Software/ESPHome/6chan_energy_meter_2-addons_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_2-addons_ethernet_waveshare.yaml
@@ -168,9 +168,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 - id: !extend ${addon1_id1}
   cs_pin: 1
 #- id: !extend ${addon1_id2}

--- a/Software/ESPHome/6chan_energy_meter_3-addons_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_3-addons_ethernet_waveshare.yaml
@@ -189,9 +189,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 - id: !extend ${addon1_id1}
   cs_pin: 1
 #- id: !extend ${addon1_id2}

--- a/Software/ESPHome/6chan_energy_meter_4-addons_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_4-addons_ethernet_waveshare.yaml
@@ -212,9 +212,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 - id: !extend ${addon1_id1}
   cs_pin: 1
 #- id: !extend ${addon1_id2}

--- a/Software/ESPHome/6chan_energy_meter_5-addons_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_5-addons_ethernet_waveshare.yaml
@@ -235,9 +235,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 - id: !extend ${addon1_id1}
   cs_pin: 1
 #- id: !extend ${addon1_id2}

--- a/Software/ESPHome/6chan_energy_meter_6-addons_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_6-addons_ethernet_waveshare.yaml
@@ -258,9 +258,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 - id: !extend ${addon1_id1}
   cs_pin: 1
 #- id: !extend ${addon1_id2}

--- a/Software/ESPHome/6chan_energy_meter_main_ethernet_waveshare.yaml
+++ b/Software/ESPHome/6chan_energy_meter_main_ethernet_waveshare.yaml
@@ -117,9 +117,9 @@ web_server:
 sensor:
 # CS Pin mappings for Waveshare ESP32-S3-ETH
 - id: !extend ${main_meter_id1}
-  cs_pin: 34
+  cs_pin: 47
 - id: !extend ${main_meter_id2}
-  cs_pin: 40
+  cs_pin: 48
 
 ## The max value for current that the meter can output is 65.535. If you expect to measure current over 65A,
 ## divide the current_cal_ctx (above) by 2 (120A CT) or 4 (200A CT) and multiply the current and power values 


### PR DESCRIPTION
### Motivation
- Ensure the Waveshare ESP32-S3-ETH ESPHome configurations use the correct chip-select pins for the main meter boards so software pin mappings match the hardware wiring.

### Description
- Change `cs_pin` for `${main_meter_id1}` from `34` to `47` in Waveshare Ethernet configs.
- Change `cs_pin` for `${main_meter_id2}` from `40` to `48` in Waveshare Ethernet configs.
- Applied the changes across the Waveshare variants: `6chan_energy_meter_main_ethernet_waveshare.yaml` and the 1-, 2-, 3-, 4-, 5-, and 6-addons Waveshare Ethernet YAML files.